### PR TITLE
Update API endpoints

### DIFF
--- a/ingestion_service/producer/core/configure_rabbit_mq.py
+++ b/ingestion_service/producer/core/configure_rabbit_mq.py
@@ -19,11 +19,13 @@ import json
 
 
 from core.configuration import load_environment
-from fastapi import HTTPException
+from fastapi.responses import JSONResponse
+import logging
 import pika
 
 # Load environment variables
 
+logger = logging.getLogger(__name__)
 
 # Retrieve username and password from environment
 rabbitmq_username = load_environment()["RABBITMQ_USERNAME"]
@@ -57,9 +59,10 @@ def publish_message(message, exchange_name="ingest_message"):
                                   delivery_mode=2,  # Make message persistent
                               ))
     except Exception as e:
-        print(f"Publisher '{exchange_name}': {e} {rabbitmq_port} {rabbitmq_url} {rabbitmq_vhost}")
-        raise HTTPException(status_code=500, detail=f"RabbitMQ: {str(e)}")
-    print(f"Published message to exchange '{exchange_name}': {message}")
+        logger.info(f"Publisher '{exchange_name}': {e} {rabbitmq_port} {rabbitmq_url} {rabbitmq_vhost}")
+
+        return JSONResponse(content={"message": "Error occured. Please contact administrator"})
+    logger.info(f"Published message to exchange '{exchange_name}': {message}")
 
     channel.close()
     connection.close()

--- a/ingestion_service/producer/core/configure_rabbit_mq.py
+++ b/ingestion_service/producer/core/configure_rabbit_mq.py
@@ -46,14 +46,15 @@ def connect_to_rabbitmq():
     return connection, channel
 
 
-def publish_message(message, exchange_name="ingest_message"):
+def publish_message(message, exchange_name="ingest_message_direct"):
     """Publish a message to a fanout exchange in RabbitMQ, meaning, there will be multiple consumers (or subscribers)
     for the same mesage."""
     connection, channel = connect_to_rabbitmq()
-    channel.exchange_declare(exchange=exchange_name, exchange_type='fanout')
+    channel.exchange_declare(exchange=exchange_name, durable=True)
     try:
+        # print(f"message to publish {message}")
         channel.basic_publish(exchange=exchange_name,
-                              routing_key='',  # Routing key is ignored by fanout exchanges
+                              routing_key='brainkb',  # Routing key is ignored by fanout exchanges
                               body=message,
                               properties=pika.BasicProperties(
                                   delivery_mode=2,  # Make message persistent

--- a/ingestion_service/producer/core/configure_rabbit_mq.py
+++ b/ingestion_service/producer/core/configure_rabbit_mq.py
@@ -52,7 +52,6 @@ def publish_message(message, exchange_name="ingest_message_direct"):
     connection, channel = connect_to_rabbitmq()
     channel.exchange_declare(exchange=exchange_name, durable=True)
     try:
-        # print(f"message to publish {message}")
         channel.basic_publish(exchange=exchange_name,
                               routing_key='brainkb',  # Routing key is ignored by fanout exchanges
                               body=message,
@@ -60,9 +59,9 @@ def publish_message(message, exchange_name="ingest_message_direct"):
                                   delivery_mode=2,  # Make message persistent
                               ))
     except Exception as e:
-        logger.info(f"Publisher '{exchange_name}': {e} {rabbitmq_port} {rabbitmq_url} {rabbitmq_vhost}")
+        logger.error(f"Publisher '{exchange_name}': {e} {rabbitmq_port} {rabbitmq_url} {rabbitmq_vhost}", exc_info=True)
 
-        return JSONResponse(content={"message": "Error occured. Please contact administrator"})
+        return JSONResponse(content={"message": "Error occured. Please contact administrator"}, status_code=400)
     logger.info(f"Published message to exchange '{exchange_name}': {message}")
 
     channel.close()

--- a/ingestion_service/producer/core/file_validator.py
+++ b/ingestion_service/producer/core/file_validator.py
@@ -16,23 +16,32 @@
 # @File    : file_validator.py
 # @Software: PyCharm
 
-ALLOWED_MIME_TYPES = {"application/json",  # JSON file
-                      "application/vnd.ms-excel",  # Excel file
-                      "text/plain",  # Plain text file
-                      "text/csv",  # CSV file
-                      "application/pdf",  # PDF file
-                      "application/rdf+xml",  # RDF/XML
-                      "application/ld+json",  # JSON-LD
-                      "text/turtle"  # Turtle
-                      }
-ALLOWED_EXTENSIONS = {".json",
-                      ".xls",
-                      ".txt",
-                      ".csv",
-                      ".pdf",
-                      ".ttl",
-                      ".rdf",
-                      "jsonld"}
+ALLOWED_MIME_TYPES = {
+    "application/json",        # JSON file
+    "application/vnd.ms-excel",# Excel file
+    "text/plain",             # Plain text file, also used for TTL
+    "text/csv",               # CSV file
+    "application/pdf",        # PDF file
+    "application/rdf+xml",    # RDF/XML
+    "application/ld+json",    # JSON-LD
+    "text/turtle",            # Turtle (TTL)
+    "application/x-turtle",   # Alternative MIME type for Turtle
+    "application/turtle"      # Another common MIME type for Turtle
+}
+
+ALLOWED_EXTENSIONS = {
+    ".json",
+    ".xls",
+    ".txt",
+    ".csv",
+    ".pdf",
+    ".ttl",
+    ".rdf",
+    ".jsonld",
+    ".n3",
+    ".nt"
+}
+
 
 
 def validate_file_extension(filename: str) -> bool:

--- a/ingestion_service/producer/core/file_validator.py
+++ b/ingestion_service/producer/core/file_validator.py
@@ -46,16 +46,15 @@ ALLOWED_KG_EXTENSIONS = {
 
 ALLOWED_RAW_FILE_EXTENSIONS = {
     ".json",
-    # ".xls",
     ".txt",
-    # ".csv",
     ".pdf",
 
 }
 
 
 def validate_file_extension(filename: str, validation_type="raw") -> bool:
-    logger.info(f"Running validate_file_extension")
+    """Validate file by checking the file extension"""
+    logger.info(f"Running validation to check if the uploaded file ({filename}) is allowed.")
     if validation_type=="kg":
         return any(filename.endswith(ext) for ext in ALLOWED_KG_EXTENSIONS)
 
@@ -63,7 +62,8 @@ def validate_file_extension(filename: str, validation_type="raw") -> bool:
 
 
 def validate_mime_type(mime_type: str, validation_type="raw") -> bool:
-    logger.info(f"Running validate_mime_type")
+    """Validate mime type of the uploaded file"""
+    logger.info(f"Running validation to check MIME type of the uploaded file.")
     if validation_type == "kg":
         return mime_type in ALLOWED_KG_MIME_TYPES
 
@@ -75,22 +75,22 @@ def is_valid_turtle(turtle_data: str) -> bool:
         graph = Graph()
         graph.parse(data=turtle_data, format="turtle")
         return True
-    except exceptions.ParserError:
-        logger.error(f"ParserError error")
+    except exceptions.ParserError as pe:
+        logger.error(f"ParserError error:  {pe}", exc_info=True)
         return False
     except Exception as e:
-        logger.error(f"Validation error: {e}")
+        logger.error(f"Validation error: {e}", exc_info=True)
         return False
 
 def is_valid_jsonld(jsonld_data: dict) -> bool:
     """Validates whether the given dictionary is a valid JSON-LD format."""
-    logger.info(f"Running is_valid_jsonld")
+    logger.info(f"Running validation to check whether the given dictionary is a valid JSON-LD format.")
     try:
         compacted = jsonld.compact(jsonld_data, jsonld_data.get("@context", {}))
         return "@context" in compacted and "@type" in compacted
-    except JSONDecodeError:
-        logger.error(f"JSONDecodeError error")
+    except JSONDecodeError as jde:
+        logger.error(f"JSONDecodeError error: {jde}", exc_info=True)
         return False
     except Exception as e:
-        logger.error(f"Validation error: {e}")
+        logger.error(f"Validation error: {e}", exc_info=True)
         return False

--- a/ingestion_service/producer/core/file_validator.py
+++ b/ingestion_service/producer/core/file_validator.py
@@ -16,37 +16,81 @@
 # @File    : file_validator.py
 # @Software: PyCharm
 
-ALLOWED_MIME_TYPES = {
+from rdflib import Graph, exceptions
+from pyld import jsonld
+from json import JSONDecodeError
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+ALLOWED_RAW_FILE_MIME_TYPES = {
     "application/json",        # JSON file
     "application/vnd.ms-excel",# Excel file
     "text/plain",             # Plain text file, also used for TTL
     "text/csv",               # CSV file
     "application/pdf",        # PDF file
-    "application/rdf+xml",    # RDF/XML
+}
+
+ALLOWED_KG_MIME_TYPES = {
     "application/ld+json",    # JSON-LD
     "text/turtle",            # Turtle (TTL)
     "application/x-turtle",   # Alternative MIME type for Turtle
     "application/turtle"      # Another common MIME type for Turtle
 }
 
-ALLOWED_EXTENSIONS = {
-    ".json",
-    ".xls",
-    ".txt",
-    ".csv",
-    ".pdf",
+ALLOWED_KG_EXTENSIONS = {
     ".ttl",
-    ".rdf",
     ".jsonld",
-    ".n3",
-    ".nt"
+}
+
+ALLOWED_RAW_FILE_EXTENSIONS = {
+    ".json",
+    # ".xls",
+    ".txt",
+    # ".csv",
+    ".pdf",
+
 }
 
 
+def validate_file_extension(filename: str, validation_type="raw") -> bool:
+    logger.info(f"Running validate_file_extension")
+    if validation_type=="kg":
+        return any(filename.endswith(ext) for ext in ALLOWED_KG_EXTENSIONS)
 
-def validate_file_extension(filename: str) -> bool:
-    return any(filename.endswith(ext) for ext in ALLOWED_EXTENSIONS)
+    return any(filename.endswith(ext) for ext in ALLOWED_RAW_FILE_EXTENSIONS)
 
 
-def validate_mime_type(mime_type: str) -> bool:
-    return mime_type in ALLOWED_MIME_TYPES
+def validate_mime_type(mime_type: str, validation_type="raw") -> bool:
+    logger.info(f"Running validate_mime_type")
+    if validation_type == "kg":
+        return mime_type in ALLOWED_KG_MIME_TYPES
+
+    return mime_type in ALLOWED_RAW_FILE_MIME_TYPES
+
+def is_valid_turtle(turtle_data: str) -> bool:
+    """Validates whether the given string is a valid Turtle format."""
+    try:
+        graph = Graph()
+        graph.parse(data=turtle_data, format="turtle")
+        return True
+    except exceptions.ParserError:
+        logger.error(f"ParserError error")
+        return False
+    except Exception as e:
+        logger.error(f"Validation error: {e}")
+        return False
+
+def is_valid_jsonld(jsonld_data: dict) -> bool:
+    """Validates whether the given dictionary is a valid JSON-LD format."""
+    logger.info(f"Running is_valid_jsonld")
+    try:
+        compacted = jsonld.compact(jsonld_data, jsonld_data.get("@context", {}))
+        return "@context" in compacted and "@type" in compacted
+    except JSONDecodeError:
+        logger.error(f"JSONDecodeError error")
+        return False
+    except Exception as e:
+        logger.error(f"Validation error: {e}")
+        return False

--- a/ingestion_service/producer/core/main.py
+++ b/ingestion_service/producer/core/main.py
@@ -18,8 +18,8 @@ app.add_middleware(CorrelationIdMiddleware)
 
 
 app.include_router(index_router, prefix="/api")
-app.include_router(jwt_router,prefix="/api", tags=["security"])
-app.include_router(ingest_api_router,prefix="/api" ,tags=["ingestion"])
+app.include_router(jwt_router, prefix="/api", tags=["Security"])
+app.include_router(ingest_api_router, prefix="/api", tags=["Ingestion"])
 
 @app.on_event("startup")
 async def startup_event():

--- a/ingestion_service/producer/core/main.py
+++ b/ingestion_service/producer/core/main.py
@@ -17,9 +17,9 @@ logger = logging.getLogger(__name__)
 app.add_middleware(CorrelationIdMiddleware)
 
 
-app.include_router(index_router)
-app.include_router(jwt_router)
-app.include_router(ingest_api_router)
+app.include_router(index_router, prefix="/api")
+app.include_router(jwt_router,prefix="/api", tags=["security"])
+app.include_router(ingest_api_router,prefix="/api" ,tags=["ingestion"])
 
 @app.on_event("startup")
 async def startup_event():

--- a/ingestion_service/producer/core/pydantic_schema.py
+++ b/ingestion_service/producer/core/pydantic_schema.py
@@ -21,7 +21,6 @@ from typing import Dict, Any
 
 
 class BaseSchema(BaseModel):
-    id: str
     user: str
     type: str
     date_created: datetime = datetime.now()
@@ -43,6 +42,7 @@ class InputJSONSLdchema(BaseModel):
 
 
 class InputTextSchema(BaseSchema):
+    type: str = "text"
     text_data: str
 
 

--- a/ingestion_service/producer/core/pydantic_schema.py
+++ b/ingestion_service/producer/core/pydantic_schema.py
@@ -15,14 +15,13 @@
 # @Web     : https://tekrajchhetri.com/
 # @File    : pydantic_schema.py
 # @Software: PyCharm
-from pydantic import BaseModel
 from datetime import datetime
 from typing import Dict, Any
+from pydantic import BaseModel, Field
 
 
 class BaseSchema(BaseModel):
     user: str
-    type: str
     date_created: datetime = datetime.now()
     date_modified: datetime = datetime.now()
 
@@ -37,69 +36,16 @@ class InputJSONSchema(BaseSchema):
 
 
 class InputJSONSLdchema(BaseModel):
-    type: str
+    user: str
     kg_data: Dict[Any, Any]
 
 
 class InputTextSchema(BaseSchema):
-    type: str = "text"
+    user: str = "testuser"
     text_data: str
 
 
-if __name__ == "__main__":
-    """Test pydantic schema"""
-    import json
-    print(InputJSONSchema.model_validate_json(
-        json.dumps(
-            {
-                "id": "1BCD",
-                "user": "U123r",
-                "date_created": "2024-04-30T12:42:32.203447",
-                "date_modified": "2024-04-30T12:42:32.203451",
-                "json_data": {
-                    "neuroscience_disorders": [
-                        {
-                            "disorder": "Alzheimer's disease",
-                            "description": "A progressive neurodegenerative disorder that leads to memory loss and cognitive decline.",
-                            "symptoms": [
-                                "Memory loss",
-                                "Confusion",
-                                "Trouble with language and reasoning"
-                            ],
-                            "treatments": [
-                                "Medications (e.g., cholinesterase inhibitors)",
-                                "Cognitive therapy"
-                            ]
-                        },
-                        {
-                            "disorder": "Parkinson's disease",
-                            "description": "A neurodegenerative disorder characterized by tremors, rigidity, and difficulty with movement.",
-                            "symptoms": [
-                                "Tremors",
-                                "Bradykinesia",
-                                "Postural instability"
-                            ],
-                            "treatments": [
-                                "Levodopa",
-                                "Deep brain stimulation (DBS)"
-                            ]
-                        },
-                        {
-                            "disorder": "Schizophrenia",
-                            "description": "A chronic and severe mental disorder that affects how a person thinks, feels, and behaves.",
-                            "symptoms": [
-                                "Hallucinations",
-                                "Delusions",
-                                "Disorganized thinking"
-                            ],
-                            "treatments": [
-                                "Antipsychotic medications",
-                                "Psychotherapy"
-                            ]
-                        }
-                    ]
-                }
-            }
-        )
-    )
-    )
+class InputTurtleSchema(BaseModel):
+    user: str = "testuser"
+    turtle_kg_data: str = Field(..., description="RDF Turtle data as a multiline string.")
+

--- a/ingestion_service/producer/core/routers/api_endpoints_input.py
+++ b/ingestion_service/producer/core/routers/api_endpoints_input.py
@@ -189,7 +189,7 @@ async def ingest_raw_jsonld(
         raise HTTPException(status_code=400, detail="Invalid JSON" + str(e))
 
     except Exception as e:
-        logger.error(f"An unexpected error occurred: {e}")
+        logger.error(f"An unexpected error occurred: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Internal Server Error: {e}")
 
 
@@ -349,7 +349,7 @@ async def ingest_knowledge_graphs_batch(
                 })
             else:
                 # This shouldn't occur due to earlier validation
-                logger.error(f"Unexpected file extension for file: {file.filename}")
+                logger.error(f"Unexpected file extension for file: {file.filename}", exc_info=True)
                 results.append({
                     "filename": file.filename,
                     "status": "failed",
@@ -357,7 +357,7 @@ async def ingest_knowledge_graphs_batch(
                 })
 
         except Exception as e:
-            logger.error(f"Error processing file {file.filename}: {str(e)}")
+            logger.error(f"Error processing file {file.filename}: {str(e)}", exc_info=True)
             results.append({
                 "filename": file.filename,
                 "status": "failed",
@@ -460,7 +460,7 @@ async def ingest_document_batch(
             })
 
         except Exception as e:
-            logger.error(f"Error processing file {file.filename}: {str(e)}")
+            logger.error(f"Error processing file {file.filename}: {str(e)}", exc_info=True)
             results.append({
                 "filename": file.filename,
                 "status": "failed",

--- a/ingestion_service/producer/core/routers/api_endpoints_input.py
+++ b/ingestion_service/producer/core/routers/api_endpoints_input.py
@@ -18,13 +18,14 @@
 
 from fastapi import APIRouter, HTTPException, Body, Depends
 from fastapi import File, Form, UploadFile, status
-# from typing import List
+from typing import List
 from fastapi.responses import JSONResponse
 from core.configure_rabbit_mq import publish_message
 import logging
 from core.file_validator import validate_file_extension, validate_mime_type
+from core.file_validator import is_valid_jsonld
 import json
-from core.pydantic_schema import InputJSONSLdchema, InputJSONSchema, InputTextSchema
+from core.pydantic_schema import InputJSONSLdchema, InputJSONSchema, InputTextSchema, InputTurtleSchema
 from core.shared import is_valid_jsonld
 from typing import Annotated
 from core.models.user import LoginUserIn
@@ -34,19 +35,20 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
-@router.post("/ingest/file", summary="Ingest a either CSV, JSON, EXCEL, PDF, RDF, TTL, JSONLD or TEXT files",
-             dependencies=[Depends(require_scopes(["write"]))])
-async def ingest_file(user: Annotated[LoginUserIn, Depends(get_current_user)],
-                      id: str = Form(...),
-                      type: str = "file",
-                      posting_user: str = Form(...),
-                      file: UploadFile = File(...)):
+@router.post("/upload/knowledge-graph", summary="Ingest a either TTL, JSONLD files",
+             dependencies=[Depends(require_scopes(["write"]))]
+             )
+async def ingest_kg_file(
+        user: Annotated[LoginUserIn, Depends(get_current_user)],
+        type: str = "file",
+        posting_user: str = Form(...),
+        file: UploadFile = File(...)):
     logger.info("Started ingestion operation")
 
     logger.debug(f"Received file: {file.filename} with type: {file.content_type}")
-    if not validate_file_extension(file.filename):
+    if not validate_file_extension(file.filename, validation_type="kg"):
         raise HTTPException(status_code=400,
-                            detail="Unsupported file extension. Supported extensions: csv, json, xls, txt and pdf")
+                            detail="Unsupported file extension. Supported extensions: TTL and JSONLD")
 
     content = await file.read()
     publish_message(content)
@@ -54,78 +56,111 @@ async def ingest_file(user: Annotated[LoginUserIn, Depends(get_current_user)],
     return JSONResponse(
         content={
             "message": "File uploaded successfully",
-            "id": id,
             "user": posting_user,
             "type": type,
             "filename": file.filename,
             "extension": file.filename.split('.')[-1].lower()
         })
 
-@router.post("/ingest/raw/json", dependencies=[Depends(require_scopes(["write"]))])
-async def ingest_json(user: Annotated[LoginUserIn, Depends(get_current_user)],
-                      jsoninput: Annotated[
-                          InputJSONSchema,
-                          Body(
-                              examples=[
-                                  {
-                                      "id": "1BCD",
-                                      "user": "U123r",
-                                      "type": "json",
-                                      "date_created": "2024-04-30T12:42:32.203447",
-                                      "date_modified": "2024-04-30T12:42:32.203451",
-                                      "json_data": {
 
-                                          "neuroscience_disorders": [
-                                              {
-                                                  "disorder": "Alzheimer's disease",
-                                                  "description": "A progressive neurodegenerative disorder that leads to memory loss and cognitive decline.",
-                                                  "symptoms": ["Memory loss", "Confusion",
-                                                               "Trouble with language and reasoning"],
-                                                  "treatments": ["Medications (e.g., cholinesterase inhibitors)",
-                                                                 "Cognitive therapy"]
-                                              },
-                                              {
-                                                  "disorder": "Parkinson's disease",
-                                                  "description": "A neurodegenerative disorder characterized by tremors, rigidity, and difficulty with movement.",
-                                                  "symptoms": ["Tremors", "Bradykinesia", "Postural instability"],
-                                                  "treatments": ["Levodopa", "Deep brain stimulation (DBS)"]
-                                              },
-                                              {
-                                                  "disorder": "Schizophrenia",
-                                                  "description": "A chronic and severe mental disorder that affects how a person thinks, feels, and behaves.",
-                                                  "symptoms": ["Hallucinations", "Delusions", "Disorganized thinking"],
-                                                  "treatments": ["Antipsychotic medications", "Psychotherapy"]
-                                              }
-                                          ]
+@router.post("/upload/document", summary="Ingest a either TXT, JSON and PDF files",
+             dependencies=[Depends(require_scopes(["write"]))]
+             )
+async def ingest_raw_file(
+        user: Annotated[LoginUserIn, Depends(get_current_user)],
+        type: str = "file",
+        posting_user: str = Form(...),
+        file: UploadFile = File(...)):
+    logger.info("Started ingestion operation")
 
-                                      }
-                                  }
-                              ],
-                          ),
-                      ], ):
+    logger.debug(f"Received file: {file.filename} with type: {file.content_type}")
+    if not validate_file_extension(file.filename, validation_type="raw"):
+        raise HTTPException(status_code=400,
+                            detail="Unsupported file extension. Supported extensions: TXT, JSON and PDF")
+
+    content = await file.read()
+    publish_message(content)
+    logger.info("Successful ingestion operation")
+    return JSONResponse(
+        content={
+            "message": "File uploaded successfully",
+            "user": posting_user,
+            "type": type,
+            "filename": file.filename,
+            "extension": file.filename.split('.')[-1].lower()
+        })
+
+
+@router.post("/ingest/raw-json",
+             dependencies=[Depends(require_scopes(["write"]))]
+             )
+async def ingest_json(
+        user: Annotated[LoginUserIn, Depends(get_current_user)],
+        jsoninput: Annotated[
+            InputJSONSchema,
+            Body(
+                examples=[
+                    {
+                        "user": "U123r",
+                        "date_created": "2024-04-30T12:42:32.203447",
+                        "date_modified": "2024-04-30T12:42:32.203451",
+                        "json_data": {
+
+                            "neuroscience_disorders": [
+                                {
+                                    "disorder": "Alzheimer's disease",
+                                    "description": "A progressive neurodegenerative disorder that leads to memory loss and cognitive decline.",
+                                    "symptoms": ["Memory loss", "Confusion",
+                                                 "Trouble with language and reasoning"],
+                                    "treatments": ["Medications (e.g., cholinesterase inhibitors)",
+                                                   "Cognitive therapy"]
+                                },
+                                {
+                                    "disorder": "Parkinson's disease",
+                                    "description": "A neurodegenerative disorder characterized by tremors, rigidity, and difficulty with movement.",
+                                    "symptoms": ["Tremors", "Bradykinesia", "Postural instability"],
+                                    "treatments": ["Levodopa", "Deep brain stimulation (DBS)"]
+                                },
+                                {
+                                    "disorder": "Schizophrenia",
+                                    "description": "A chronic and severe mental disorder that affects how a person thinks, feels, and behaves.",
+                                    "symptoms": ["Hallucinations", "Delusions", "Disorganized thinking"],
+                                    "treatments": ["Antipsychotic medications", "Psychotherapy"]
+                                }
+                            ]
+
+                        }
+                    }
+                ],
+            ),
+        ], ):
     try:
         main_model_schema = jsoninput.json()
         publish_message(main_model_schema)
     except json.JSONDecodeError as e:
         raise HTTPException(status_code=400, detail="Invalid JSON" + str(e))
 
-    return JSONResponse(content={"message": f"Data uploaded successfully {main_model_schema}"})
+    return JSONResponse(content={"message": "Data uploaded successfully"})
 
 
-@router.post("/ingest/raw/jsonld")
-async def ingest_json(user: Annotated[LoginUserIn, Depends(get_current_user)],
-                      jsonldinput: Annotated[
-                          InputJSONSLdchema,
-                          Body(
-                              examples=[
-                                  {
-                                      "type": "jsonld",
-                                      "kg_data": {"@context": "https://schema.org", "@type": "Person",
-                                                  "name": "John Doe"}
-                                  }
-                              ],
-                          ),
-                      ], ):
+@router.post("/ingest/raw-jsonld",
+             dependencies=[Depends(require_scopes(["write"]))]
+             )
+async def ingest_raw_json(
+        user: Annotated[LoginUserIn, Depends(get_current_user)],
+        jsonldinput:
+        Annotated[
+            InputJSONSLdchema,
+            Body(
+                examples=[
+                    {
+                        "user": "testuser",
+                        "kg_data": {"@context": "https://schema.org", "@type": "Person",
+                                    "name": "John Doe"}
+                    }
+                ],
+            ),
+        ], ):
     try:
 
         json_data = jsonldinput.json()
@@ -139,24 +174,166 @@ async def ingest_json(user: Annotated[LoginUserIn, Depends(get_current_user)],
         raise HTTPException(status_code=400, detail="Invalid JSON" + str(e))
 
 
-@router.post("/ingest/raw/text/", dependencies=[Depends(require_scopes(["write"]))])
-async def ingest_text(user: Annotated[LoginUserIn, Depends(get_current_user)],
+@router.post("/upload/knowledge-graphs",
+             summary="Batch ingest multiple files ( TTL and JSONLD)",
+             status_code=status.HTTP_207_MULTI_STATUS,
+             dependencies=[Depends(require_scopes(["write"]))]
+             )
+async def ingest_knowledge_graphs_batch(
+        user: Annotated[LoginUserIn, Depends(get_current_user)],
+        files: List[UploadFile] = File(...),
+        posting_user: str = Form(...),
+):
+    if not files:
+        raise HTTPException(status_code=400, detail="No files provided")
+
+    # Validate all files are of the same type
+    first_file_ext = files[0].filename.split('.')[-1].lower()
+    if not all(f.filename.split('.')[-1].lower() == first_file_ext for f in files):
+        raise HTTPException(
+            status_code=400,
+            detail=f"All files in a batch must be of the same type. Expected: {first_file_ext}"
+        )
+
+
+
+    if not validate_file_extension(files[0].filename,
+                                   validation_type="kg"):
+        raise HTTPException(
+            status_code=400,
+            detail="Unsupported file extension. Supported extensions: TTL and JSONLD"
+        )
+
+
+    logger.info(f"Started batch ingestion operation for file type: {first_file_ext}")
+
+    results = []
+    for file in files:
+        try:
+            content = await file.read()
+
+            logger.info(f"Publishing batch knowledge graphs content - {file}")
+
+            publish_message(content)
+            results.append({
+                "filename": file.filename,
+                "status": "success",
+                "message": "File uploaded successfully"
+            })
+
+        except Exception as e:
+            logger.error(f"Error processing file {file.filename}: {str(e)}")
+            results.append({
+                "filename": file.filename,
+                "status": "failed",
+                "message": f"Error processing file: {str(e)}"
+            })
+
+    logger.info(f"Completed batch ingestion operation")
+
+    return JSONResponse(
+        content={
+            "posting_user": posting_user,
+            "total_files": len(files),
+            "successful": len([r for r in results if r["status"] == "success"]),
+            "failed": len([r for r in results if r["status"] == "failed"]),
+            "results": results
+        }
+    )
+
+
+@router.post("/upload/documents",
+             summary="Batch ingest multiple files (JSON, PDF and TXT)",
+             status_code=status.HTTP_207_MULTI_STATUS,
+             dependencies=[Depends(require_scopes(["write"]))]
+             )
+async def ingest_document_batch(
+        user: Annotated[LoginUserIn, Depends(get_current_user)],
+        files: List[UploadFile] = File(...),
+        posting_user: str = Form(...),
+):
+    if not files:
+        raise HTTPException(status_code=400, detail="No files provided")
+
+    # Validate all files are of the same type
+    first_file_ext = files[0].filename.split('.')[-1].lower()
+    if not all(f.filename.split('.')[-1].lower() == first_file_ext for f in files):
+        raise HTTPException(
+            status_code=400,
+            detail=f"All files in a batch must be of the same type. Expected: {first_file_ext}"
+        )
+
+    # Validate first file to ensure type is supported
+    if not validate_mime_type(files[0].content_type):
+        raise HTTPException(
+            status_code=400,
+            detail="Only JSON,  PDF and TEXT files are supported."
+        )
+
+    if not validate_file_extension(files[0].filename):
+        raise HTTPException(
+            status_code=400,
+            detail="Unsupported file extension. Supported extensions: JSON,  PDF and TEXT"
+        )
+
+
+
+    logger.info(f"Started batch ingestion operation for file type: {first_file_ext}")
+
+    results = []
+    for file in files:
+        try:
+            content = await file.read()
+
+            publish_message(content)
+
+            results.append({
+                "filename": file.filename,
+                "status": "success",
+                "message": "File uploaded successfully"
+            })
+
+        except Exception as e:
+            logger.error(f"Error processing file {file.filename}: {str(e)}")
+            results.append({
+                "filename": file.filename,
+                "status": "failed",
+                "message": f"Error processing file: {str(e)}"
+            })
+
+    logger.info(f"Completed batch ingestion operation")
+
+    return JSONResponse(
+        content={
+            "posting_user": posting_user,
+            "total_files": len(files),
+            "successful": len([r for r in results if r["status"] == "success"]),
+            "failed": len([r for r in results if r["status"] == "failed"]),
+            "results": results
+        }
+    )
+
+
+@router.post("/ingest/raw/text/",
+             dependencies=[Depends(require_scopes(["write"]))]
+             )
+async def ingest_text(
+        user: Annotated[LoginUserIn, Depends(get_current_user)],
                       text:
                       Annotated[
                           InputTextSchema,
                           Body(
                               examples=[
                                   {
-                                      "id": "1BCD",
                                       "user": "U123r",
-                                      "type":"text",
+                                      "type": "text",
                                       "date_created": "2024-04-30T12:42:32.203447",
                                       "date_modified": "2024-04-30T12:42:32.203451",
-                                      "text_data": "This is sample text data for KGs construction"
+                                      "text_data": "Lorem ipsum odor amet, consectetuer adipiscing elit. Scelerisque nostra potenti erat vivamus facilisis netus; egestas hac. Ullamcorper vivamus maecenas conubia nam dui felis at eu. Ac a fames velit penatibus adipiscing. Pulvinar imperdiet habitasse sed taciti venenatis posuere augue. Duis dolor massa curae interdum habitant ultrices aliquam adipiscing aliquet. Sapien eu parturient at curabitur ac ullamcorper suspendisse. Molestie imperdiet in turpis sit ullamcorper risus ipsum aliquet elit. Magnis libero cras potenti litora arcu nunc? Rhoncus enim ipsum cras sit semper accumsan. Tempor aliquam amet massa pharetra tristique metus imperdiet. Arcu vestibulum ex dapibus posuere augue conubia nullam faucibus. Erat sodales rhoncus tincidunt nascetur lacus neque. Lectus ante consequat ex ligula vel imperdiet. Natoque sollicitudin quam pretium; nibh duis malesuada. Consectetur augue tellus eget ligula class accumsan? Auctor id semper purus dignissim; montes posuere velit. Donec tempor tempus etiam litora integer. Viverra quam senectus ac, et dapibus inceptos adipiscing montes auctor. Integer convallis nisi himenaeos aliquet lacinia sodales. Eleifend nascetur viverra per libero a neque. Sagittis lorem ligula fusce elit blandit magnis turpis hendrerit. Blandit quisque etiam diam quisque vivamus. Conubia hac elementum porta dis hendrerit conubia sit. Cursus penatibus ridiculus arcu turpis mi vitae nostra. Vulputate blandit dui quam nibh congue curae magnis. Ridiculus sapien vel senectus augue tellus massa. Eu laoreet etiam placerat lobortis convallis metus efficitur metus. Laoreet non dui placerat nec magna. Conubia etiam in tellus vestibulum convallis erat. Orci elit volutpat felis dui venenatis nisi malesuada nec. Non dapibus suspendisse vitae inceptos viverra tellus eu. Ante volutpat enim interdum non pellentesque. Felis est curae maximus placerat eleifend phasellus quam in. Tortor senectus dictum proin aptent; tortor bibendum rhoncus. Varius nam semper nisi mus varius justo ridiculus. Molestie fusce etiam tellus diam fames. Sagittis orci ex efficitur, taciti sapien consequat condimentum viverra."
                                   }
                               ],
                           ),
                       ], ):
     text_data = text.json()
     publish_message(text_data)
-    return JSONResponse(content={"message": "File uploaded successfully"})
+    return JSONResponse(content={"message": "Text uploaded successfully"})

--- a/ingestion_service/producer/core/routers/api_endpoints_input.py
+++ b/ingestion_service/producer/core/routers/api_endpoints_input.py
@@ -435,7 +435,7 @@ async def ingest_document_batch(
     )
 
 
-@router.post("/ingest/raw/text/",
+@router.post("/ingest/raw-text",
              dependencies=[Depends(require_scopes(["write"]))]
              )
 async def ingest_text(

--- a/ingestion_service/producer/core/routers/index.py
+++ b/ingestion_service/producer/core/routers/index.py
@@ -19,6 +19,10 @@ from fastapi import APIRouter
 router = APIRouter()
 
 
-@router.get("/")
+@router.get("/home")
 async def root():
     return {"message": "Welcome to the producer ingest service"}
+
+@router.get("/health")
+async def health_check():
+    return {"status": "healthy"}

--- a/ingestion_service/producer/core/shared.py
+++ b/ingestion_service/producer/core/shared.py
@@ -18,6 +18,86 @@
 
 
 import json
+from rdflib import Graph
+import requests
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Helper function to resolve issues during the conversion from JSON-LD to Turtle representation.
+#
+# Problem:
+# The generated Turtle representation includes local file paths
+# (e.g., <file:///Users/tekrajchhetri/Documents/convert_to_ttl/...>)
+# instead of the correct base IRI.
+#
+# Expected Output:
+# The Turtle representation should look like this:
+# bican:ID123 a bican:GeneAnnotation ;
+#     rdfs:label "LOC106504536" ;
+#     schema1:identifier "106504536" ;
+#     biolink:in_taxon_label "Sus scrofa" .
+#
+# Issue:
+# Currently, the output includes local file paths, for example:
+# <file:///Users/tekrajchhetri/Documents/convert_to_ttl/000015fd3d6a449b47e75651210a6cc74fca918255232c8af9e46d077034c84d>
+# a bican:GeneAnnotation ;
+#     rdfs:label "LOC106504536" ;
+#     schema1:identifier "106504536" ;
+#     biolink:in_taxon_label "Sus scrofa" .
+#
+# This function ensures that the base IRI is used, correcting the issue.
+def _get_base_from_context(jsonld_data):
+    """
+    Extracts the @base value from the @context.
+    Handles both inline contexts (dictionaries) and external contexts (strings).
+    Raises an error if neither @base nor @vocab is available.
+    """
+    logger.info("Extracting base ")
+    context = jsonld_data.get('@context', {})
+
+    # If @context is a string, fetch the external context
+    if isinstance(context, str):
+        try:
+            response = requests.get(context)
+            response.raise_for_status()
+            context_data = response.json()
+        except requests.exceptions.RequestException as e:
+            logger.error(f"Failed to fetch the external context from {context}: {e}")
+            raise ValueError(f"Failed to fetch the external context from {context}: {e}")
+
+    # Ensure context is now a dictionary
+    if not isinstance(context_data, dict):
+        logger.error(f"The @context must resolve to a dictionary. Found: {type(context)}")
+        raise ValueError(f"The @context must resolve to a dictionary. Found: {type(context)}")
+
+
+    to_fetch_context = context_data.get("@context")
+
+    base = to_fetch_context.get('@base', to_fetch_context.get('@vocab'))
+
+    if not base:
+        # Raise an error if neither @base nor @vocab is found
+        logger.error("The JSON-LD context does not contain '@base' or '@vocab'. Please define a base URI in the context.")
+        raise ValueError(
+            "The JSON-LD context does not contain '@base' or '@vocab'. "
+            "Please define a base URI in the context."
+        )
+
+    return base
+
+
+def _convert_to_turtle(jsonld_data):
+    """
+    Converts JSON-LD data to Turtle format.
+    """
+    logger.info("Converting JSON-LD data to Turtle format")
+    base = _get_base_from_context(jsonld_data)
+    graph = Graph()
+    graph.parse(data=json.dumps(jsonld_data), format='json-ld', base=base)
+    return graph.serialize(format="turtle")
+
+
 
 def has_context(json_obj):
     """Simple JSON-LD check for presence of the context"""


### PR DESCRIPTION
This pull requests makes the following update:

- Re-organized API endpoints name to make it more descriptive.
- Implements the features that were lacking previously. Now once can upload file (JSON, TTL, JSONLD -- single and multiple) as well as raw contents which will be published to RabbitMQ that worker can consume.
- Implements the feature that allows automated conversion of the uploaded jsonld files to turtle for further processing.
- Implements the features to handle the jsonld to turtle conversion issue, i.e., the file path were present instead of the base IRI (see [models/issues/88](https://github.com/brain-bican/models/issues/88) )
 
**Swagger doc**
![image](https://github.com/user-attachments/assets/9b069889-d4a2-4c94-863c-862a027c0dec)
