### PR TITLE
Add longer web-session and issue a web refresh token

### DIFF
--- a/env.template
+++ b/env.template
@@ -124,10 +124,14 @@ USERMANAGEMENT_JWT_ISSUER=brainkb-usermanagement
 # own MCP_SESSION_TTL_MIN) — see brainkb_mcp/.env.example.
 USERMANAGEMENT_ACCESS_TOKEN_TTL_MIN=15
 USERMANAGEMENT_REFRESH_TOKEN_TTL_MIN=720
-# TTL (minutes) of the web-session JWT the UI receives at OAuth login (?token=).
-# It is stored in the NextAuth session and is NOT auto-refreshed, so if it's too
-# short the web UI starts returning 401 (/api/users/me) mid-session. 720 = 12h.
+# TTL (minutes) of the web-session ACCESS JWT the UI receives at OAuth login
+# (?token=). The UI silently refreshes it using the web refresh token below, so
+# this can stay short-ish. 720 = 12h.
 USERMANAGEMENT_WEB_SESSION_TTL_MIN=720
+# TTL (minutes) of the web REFRESH token (?refresh=) the UI stores to renew its
+# access token without re-login (exchanged at /api/auth/exchange). Governs the
+# overall web session length before the user must sign in again. 10080 = 7 days.
+USERMANAGEMENT_WEB_REFRESH_TTL_MIN=10080
 # Services a refresh token may be exchanged for (valid `aud` values).
 USERMANAGEMENT_TOKEN_AUDIENCES=usermanagement,query_service,ml_service,chat_service
 

--- a/env.template
+++ b/env.template
@@ -124,6 +124,10 @@ USERMANAGEMENT_JWT_ISSUER=brainkb-usermanagement
 # own MCP_SESSION_TTL_MIN) — see brainkb_mcp/.env.example.
 USERMANAGEMENT_ACCESS_TOKEN_TTL_MIN=15
 USERMANAGEMENT_REFRESH_TOKEN_TTL_MIN=720
+# TTL (minutes) of the web-session JWT the UI receives at OAuth login (?token=).
+# It is stored in the NextAuth session and is NOT auto-refreshed, so if it's too
+# short the web UI starts returning 401 (/api/users/me) mid-session. 720 = 12h.
+USERMANAGEMENT_WEB_SESSION_TTL_MIN=720
 # Services a refresh token may be exchanged for (valid `aud` values).
 USERMANAGEMENT_TOKEN_AUDIENCES=usermanagement,query_service,ml_service,chat_service
 

--- a/usermanagement_service/core/configuration.py
+++ b/usermanagement_service/core/configuration.py
@@ -79,6 +79,10 @@ def load_environment(env_name="env"):
         "USERMANAGEMENT_JWT_PRIVATE_KEY_FILE": os.getenv("USERMANAGEMENT_JWT_PRIVATE_KEY_FILE"),
         "USERMANAGEMENT_ACCESS_TOKEN_TTL_MIN": os.getenv("USERMANAGEMENT_ACCESS_TOKEN_TTL_MIN", "15"),
         "USERMANAGEMENT_REFRESH_TOKEN_TTL_MIN": os.getenv("USERMANAGEMENT_REFRESH_TOKEN_TTL_MIN", "720"),
+        # TTL of the web-session JWT handed to the UI at OAuth login (?token=).
+        # It lives in the NextAuth session and is NOT auto-refreshed, so a too-short
+        # value makes the UI 401 mid-session. Default 12h.
+        "USERMANAGEMENT_WEB_SESSION_TTL_MIN": os.getenv("USERMANAGEMENT_WEB_SESSION_TTL_MIN", "720"),
         # Services a refresh token may be exchanged for (valid aud values).
         "USERMANAGEMENT_TOKEN_AUDIENCES": os.getenv("USERMANAGEMENT_TOKEN_AUDIENCES", "usermanagement,query_service,ml_service,chat_service"),
 
@@ -191,6 +195,14 @@ class Configuration:
     def refresh_token_ttl_min(self) -> int:
         try:
             return int(self._env_vars.get("USERMANAGEMENT_REFRESH_TOKEN_TTL_MIN", "720"))
+        except (TypeError, ValueError):
+            return 720
+
+    @property
+    def web_session_ttl_min(self) -> int:
+        """TTL (minutes) of the web-session JWT issued to the UI at OAuth login."""
+        try:
+            return int(self._env_vars.get("USERMANAGEMENT_WEB_SESSION_TTL_MIN", "720"))
         except (TypeError, ValueError):
             return 720
 

--- a/usermanagement_service/core/configuration.py
+++ b/usermanagement_service/core/configuration.py
@@ -79,10 +79,12 @@ def load_environment(env_name="env"):
         "USERMANAGEMENT_JWT_PRIVATE_KEY_FILE": os.getenv("USERMANAGEMENT_JWT_PRIVATE_KEY_FILE"),
         "USERMANAGEMENT_ACCESS_TOKEN_TTL_MIN": os.getenv("USERMANAGEMENT_ACCESS_TOKEN_TTL_MIN", "15"),
         "USERMANAGEMENT_REFRESH_TOKEN_TTL_MIN": os.getenv("USERMANAGEMENT_REFRESH_TOKEN_TTL_MIN", "720"),
-        # TTL of the web-session JWT handed to the UI at OAuth login (?token=).
-        # It lives in the NextAuth session and is NOT auto-refreshed, so a too-short
-        # value makes the UI 401 mid-session. Default 12h.
+        # TTL of the web-session ACCESS JWT handed to the UI at OAuth login
+        # (?token=). Short-lived; the UI silently refreshes it. Default 12h.
         "USERMANAGEMENT_WEB_SESSION_TTL_MIN": os.getenv("USERMANAGEMENT_WEB_SESSION_TTL_MIN", "720"),
+        # TTL of the web REFRESH token (?refresh=) the UI stores to mint new access
+        # tokens without re-login. Governs the overall web session length. 7d.
+        "USERMANAGEMENT_WEB_REFRESH_TTL_MIN": os.getenv("USERMANAGEMENT_WEB_REFRESH_TTL_MIN", "10080"),
         # Services a refresh token may be exchanged for (valid aud values).
         "USERMANAGEMENT_TOKEN_AUDIENCES": os.getenv("USERMANAGEMENT_TOKEN_AUDIENCES", "usermanagement,query_service,ml_service,chat_service"),
 
@@ -200,11 +202,20 @@ class Configuration:
 
     @property
     def web_session_ttl_min(self) -> int:
-        """TTL (minutes) of the web-session JWT issued to the UI at OAuth login."""
+        """TTL (minutes) of the web-session ACCESS JWT issued to the UI at login."""
         try:
             return int(self._env_vars.get("USERMANAGEMENT_WEB_SESSION_TTL_MIN", "720"))
         except (TypeError, ValueError):
             return 720
+
+    @property
+    def web_refresh_ttl_min(self) -> int:
+        """TTL (minutes) of the web REFRESH token the UI stores to renew access
+        tokens without re-login. Governs overall web session length."""
+        try:
+            return int(self._env_vars.get("USERMANAGEMENT_WEB_REFRESH_TTL_MIN", "10080"))
+        except (TypeError, ValueError):
+            return 10080
 
     @property
     def token_audiences(self) -> list:

--- a/usermanagement_service/core/routers/oauth.py
+++ b/usermanagement_service/core/routers/oauth.py
@@ -360,6 +360,10 @@ async def oauth_callback(
                 roles=existing_roles,
                 scopes=scopes,
                 auth_source=provider.name,
+                # Web-session TTL (default 12h), not the 30-min default: this token
+                # lives in the NextAuth session and isn't auto-refreshed, so a short
+                # TTL made the UI 401 (/api/users/me) mid-session.
+                expires_minutes=config.web_session_ttl_min,
             )
             # CLI/skill (paste-code) flow: mint an SSO refresh token and stash it
             # behind a short code the browser will display for the user to paste.

--- a/usermanagement_service/core/routers/oauth.py
+++ b/usermanagement_service/core/routers/oauth.py
@@ -365,6 +365,19 @@ async def oauth_callback(
                 # TTL made the UI 401 (/api/users/me) mid-session.
                 expires_minutes=config.web_session_ttl_min,
             )
+            # Web flow: also mint a longer-lived REFRESH token so the UI can renew
+            # its access token silently (no re-login) until this expires. Exchanged
+            # by the UI at /api/auth/exchange (audience=usermanagement).
+            web_refresh = None
+            if login_mode != "cli":
+                web_refresh = tokens_rs256.create_refresh_token(
+                    email=profile.email,
+                    profile_id=profile.id,
+                    roles=existing_roles,
+                    scopes=scopes,
+                    auth_source=provider.name,
+                    expires_minutes=config.web_refresh_ttl_min,
+                )
             # CLI/skill (paste-code) flow: mint an SSO refresh token and stash it
             # behind a short code the browser will display for the user to paste.
             if login_mode == "cli":
@@ -397,6 +410,8 @@ async def oauth_callback(
         return HTMLResponse(_cli_success_page(cli_code))
 
     qs = {"token": token}
+    if web_refresh:
+        qs["refresh"] = web_refresh
     if redirect_after_login:
         qs["redirect"] = redirect_after_login
     return RedirectResponse(f"{config.frontend_callback_url}?{urlencode(qs)}", status_code=302)

--- a/usermanagement_service/core/security.py
+++ b/usermanagement_service/core/security.py
@@ -100,9 +100,14 @@ def create_access_token_v2(
     roles: List[str],
     scopes: List[str],
     auth_source: str = "password",
+    expires_minutes: Optional[int] = None,
 ) -> str:
     """Create a JWT carrying both JWT-level scopes and profile-level roles.
-    auth_source: 'password' | 'github' | 'orcid' | 'globus'."""
+    auth_source: 'password' | 'github' | 'orcid' | 'globus'.
+    expires_minutes overrides the default 30-min TTL — the OAuth callback passes a
+    longer web-session TTL so the browser session token doesn't lapse after 30 min
+    and break the UI (it is stored in the NextAuth session and not auto-refreshed)."""
+    ttl = expires_minutes if (expires_minutes and expires_minutes > 0) else ACCESS_TOKEN_EXPIRE_MINUTES
     to_encode = {
         "sub": email,
         "scopes": scopes,
@@ -110,7 +115,7 @@ def create_access_token_v2(
         "profile_id": profile_id,
         "roles": roles,
         "auth_source": auth_source,
-        "exp": datetime.utcnow() + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES),
+        "exp": datetime.utcnow() + timedelta(minutes=ttl),
     }
     return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
 

--- a/usermanagement_service/core/tokens_rs256.py
+++ b/usermanagement_service/core/tokens_rs256.py
@@ -148,11 +148,15 @@ def create_refresh_token(
     roles: List[str],
     scopes: List[str],
     auth_source: str = "password",
+    expires_minutes: Optional[int] = None,
 ) -> str:
     """Mint the login/refresh token (aud=brainkb-auth). Not accepted by services;
-    only exchangeable at /api/auth/exchange for a per-service access token."""
+    only exchangeable at /api/auth/exchange for a per-service access token.
+    expires_minutes overrides the default refresh TTL (the web flow passes a longer
+    one so the browser session can silently refresh over several days)."""
     _load_or_generate()
     now = _now()
+    ttl = expires_minutes if (expires_minutes and expires_minutes > 0) else config.refresh_token_ttl_min
     claims = {
         "iss": config.jwt_issuer,
         "aud": REFRESH_AUDIENCE,
@@ -163,7 +167,7 @@ def create_refresh_token(
         "scopes": scopes,
         "auth_source": auth_source,
         "iat": now,
-        "exp": now + timedelta(minutes=config.refresh_token_ttl_min),
+        "exp": now + timedelta(minutes=ttl),
     }
     return jwt.encode(claims, _private_pem, algorithm=ALGORITHM, headers={"kid": _kid})
 


### PR DESCRIPTION
This PR adds longer web-session token so the UI stops 401-ing mid-session and issue a web refresh token at OAuth login for silent renew.