### PR TITLE
Route Review RDF Through BrainKB Ingest and Disable Direct Oxigraph Push

### DIFF
--- a/ml_service/core/synth_scholar/backfill_oxigraph_push.py
+++ b/ml_service/core/synth_scholar/backfill_oxigraph_push.py
@@ -1,6 +1,13 @@
 """One-shot backfill — push every completed review's RDF to Oxigraph.
 
-Use cases:
+LEGACY. This is the direct-to-Oxigraph path, which writes triples without an ingest
+job, without PROV-O provenance and without a search-index row — a named graph that
+belongs to no space and that only an Admin SPARQL query can see. Reviews now reach
+BrainKB by ingesting their TTL export through query_service (see the `brainkb` skill,
+"Ingest a SynthScholar review"), which attributes the write to a real user. This
+script refuses to run unless SYNTH_SCHOLAR_PUSH_TO_GRAPHDB is explicitly enabled.
+
+Use cases (all predate the ingest path):
 
 * You ran reviews **before** the auto-push (mark_completed → oxigraph_push)
   was wired in.  Their result_json is sitting in Postgres but no triples
@@ -35,6 +42,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
+import os
 import sys
 from typing import Any, Optional
 
@@ -42,7 +50,7 @@ from sqlalchemy import select
 
 from .database import async_session
 from .db_models import ReviewRow
-from .oxigraph_push import push_review_to_oxigraph
+from .oxigraph_push import _truthy, push_review_to_oxigraph
 
 logger = logging.getLogger("backfill_oxigraph_push")
 
@@ -136,6 +144,23 @@ async def main_async(argv: list[str] | None = None) -> int:
         level=logging.DEBUG if args.verbose else logging.INFO,
         format="%(asctime)s %(levelname)-7s %(name)s: %(message)s",
     )
+
+    # The direct push is off by default now (reviews go through the query_service
+    # ingest pipeline instead, so they get provenance). Without this guard the
+    # backfill would report "pushed N reviews" while _make_config returned None for
+    # every one of them and nothing left the process — a silent no-op is the worst
+    # possible outcome for a one-shot repair script.
+    if not _truthy(os.getenv("SYNTH_SCHOLAR_PUSH_TO_GRAPHDB"), default=False):
+        logger.error(
+            "SYNTH_SCHOLAR_PUSH_TO_GRAPHDB is not enabled, so every push would be "
+            "skipped. Reviews now reach BrainKB by ingesting their TTL export "
+            "through query_service, which is what records provenance — see the "
+            "`brainkb` skill, 'Ingest a SynthScholar review'. To run this legacy "
+            "direct push anyway, set SYNTH_SCHOLAR_PUSH_TO_GRAPHDB=true, and make "
+            "sure nothing else writes the same named graph (ingest is append-only "
+            "and the export's blank nodes do not de-duplicate)."
+        )
+        return 2
 
     rows = await _select_reviews(args.review_id or None)
     if args.limit is not None:

--- a/ml_service/core/synth_scholar/oxigraph_push.py
+++ b/ml_service/core/synth_scholar/oxigraph_push.py
@@ -22,8 +22,11 @@ Environment variables consumed
 ``GRAPHDATABASE_TYPE``                        Informational; only ``OXIGRAPH`` triggers
                                               the GSP path. Default ``OXIGRAPH``.
 ``SYNTH_SCHOLAR_PUSH_TO_GRAPHDB``             Feature flag (``true``/``false``).
-                                              Default ``true`` — set to ``false`` to
-                                              disable the push without unsetting creds.
+                                              **Default ``false``** — reviews now
+                                              reach BrainKB through the query_service
+                                              ingest pipeline instead, which is what
+                                              gives them provenance. See the note in
+                                              ``_make_config`` before enabling.
 ``SYNTH_SCHOLAR_GRAPHDB_PATH``                Endpoint path (default ``/store`` for GSP,
                                               use ``/update`` for SPARQL Update).
 ``SYNTH_SCHOLAR_GRAPHDB_NAMED_GRAPH_PREFIX``  IRI prefix for review-specific named graphs.
@@ -93,7 +96,23 @@ def _make_config():
     optional ``synthscholar`` import fails, or when no usable endpoint can
     be composed.
     """
-    if not _truthy(os.getenv("SYNTH_SCHOLAR_PUSH_TO_GRAPHDB"), default=True):
+    # Default OFF. This path writes to Oxigraph directly, which means it produces no
+    # ingest job, no PROV-O provenance and no search-index row — the triples land in
+    # a named graph that belongs to no space, so nothing except an Admin SPARQL query
+    # can see them. Reviews now reach BrainKB the same way all other RDF does: the
+    # TTL export is ingested through query_service (see the `brainkb` skill,
+    # "Ingest a SynthScholar review"), which attributes the write to a real user.
+    #
+    # Leaving this on alongside that ingest gives every review TWO graphs, not one.
+    # Review ids are unique, so reviews never collide with each other — the problem
+    # is that the two writers disagree about the IRI by one character.
+    # _named_graph_for below returns prefix + review_id with no trailing slash, while
+    # the ingest path registers and writes .../<review_id>/ (query_service normalises
+    # the registry lookup but writes the IRI verbatim). The result is a governed graph
+    # plus an unregistered shadow copy that only an Admin SPARQL query can see, which
+    # is worse than either outcome alone: search and provenance describe one of them
+    # and the store holds both.
+    if not _truthy(os.getenv("SYNTH_SCHOLAR_PUSH_TO_GRAPHDB"), default=False):
         return None
 
     try:


### PR DESCRIPTION
Reviews were being pushed directly to Oxigraph over GSP, bypassing BrainKB’s normal ingest pipeline. This meant no ingest job, provenance, search indexing, or space ownership.

This PR makes the BrainKB ingest path the single source of truth:

* Review TTL now goes through `query_service`, creating the proper job, delta, provenance, and user attribution.
* Disables the direct Oxigraph path, which could create a duplicate shadow graph due to the trailing-slash difference in graph IRIs.
* `backfill_oxigraph_push.py` now fails clearly when direct push is disabled instead of reporting a successful no-op.
* Updates env-var documentation and module docstrings to point to the current ingest path.

This keeps each review in one governed, discoverable graph and avoids accidentally re-enabling the legacy path.
